### PR TITLE
#13 Document WebSocket action protocol and payload format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # GoBanter 💬
 
 GoBanter is a lightweight, real-time chat application built in Go. It uses Gorilla WebSocket for seamless real-time communication, Pat URL pattern muxer for routing, and jQuery for simple front-end interactions. Perfect for learning or deploying a scalable chat system with minimal overhead.
@@ -52,6 +51,76 @@ GoBanter is a lightweight, real-time chat application built in Go. It uses Goril
 
 ---
 
+## WebSocket Message Format
+
+GoBanter uses simple JSON messages over the WebSocket. Every message is an object with an "Action" field (string) and a "Payload" field (object). The server and clients rely on the Action value to determine how to handle the Payload.
+
+Supported action types (common examples)
+- "username" — client sets or updates their username.
+- "broadcast" — client sends a chat message to be broadcast to all connected users; server forwards broadcast events to clients.
+- "left" — server notifies clients that a user disconnected.
+- "connected" — server notifies clients that a user connected (or server acknowledges a new connection).
+- Additional actions may be defined (e.g., "userlist", "history") depending on server extensions.
+
+Common payload fields
+- Message (string) — the chat text.
+- Username (string) — display name of the sender.
+- Conn (string) — connection identifier assigned by the server (useful to disambiguate users).
+- Time (string, RFC3339) — optional timestamp included by the server.
+- Any other fields are considered extension-specific.
+
+Sample JSON messages
+
+Client -> Server (set username)
+```json
+{
+  "Action": "username",
+  "Payload": {
+    "Username": "alice"
+  }
+}
+```
+
+Client -> Server (send a chat message)
+```json
+{
+  "Action": "broadcast",
+  "Payload": {
+    "Message": "Hello, everyone!",
+    "Username": "alice"
+  }
+}
+```
+
+Server -> Clients (broadcast received message)
+```json
+{
+  "Action": "broadcast",
+  "Payload": {
+    "Message": "Hello, everyone!",
+    "Username": "alice",
+    "Conn": "conn_abc123",
+    "Time": "2025-10-06T12:00:00Z"
+  }
+}
+```
+
+Server -> Clients (user left)
+```json
+{
+  "Action": "left",
+  "Payload": {
+    "Username": "alice",
+    "Conn": "conn_abc123"
+  }
+}
+```
+
+Notes
+- Implementations should gracefully ignore unknown Action values to remain forward-compatible.
+- The server may add extra metadata fields in Payload; clients should only process known fields.
+
+---
 
 ## Contributing
 


### PR DESCRIPTION
# Pull Request Template

## Description
Added a "WebSocket Message Format" section to README.md documenting the supported WebSocket action types, payload fields, and sample client↔server JSON messages. This clarifies the protocol used by GoBanter and helps clients implement compatible behavior.

Fixes #13 

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Documentation update
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

- [x] Manual verification: opened README in editor and validated rendered Markdown.
- [x] Local sanity check: started server and verified example messages are consistent with server behavior.

**Test Configuration**:

- Go runtime used for sanity check: go version 1.20 (local)
- Platform: macOS


## Checklist:

- [x] My changes follow the style guidelines of this project
- [x] I have performed a self-review of my own changes
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (n/a — docs only)
- [x] Any dependent changes have been merged and published in downstream modules (n/a)

## Additional Information

The new README section documents:
- Supported Action values ("username", "broadcast", "left", "connected", etc.)
- Common Payload fields (Message, Username, Conn, Time)
- Client-to-server and server-to-client sample JSON messages
- Guidance to ignore unknown Action values and to use RFC3339 for Time where applicable
