### PR TITLE
[Feature] Add typing indicator for users

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -25,6 +25,11 @@
     border-radius: 0.5rem;
 }
 
+#typing-indicator {
+    font-style: italic;
+    margin-top: 5px;
+}
+
 .private-message {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     border-left: 4px solid #5a67d8;

--- a/assets/javascript/main.js
+++ b/assets/javascript/main.js
@@ -1,4 +1,5 @@
 let socket = null;
+let typingTimer;
 
 $(document).ready(function () {
     const offline = `<span class="badge bg-danger">Not connected</span>`;
@@ -46,6 +47,10 @@ $(document).ready(function () {
                 updateRecipientList(data.connected_users);
                 break;
 
+            case "typing":
+                showTypingIndicator(data.from);
+                break;
+
             case "broadcast":
                 displayBroadcastMessage(data);
                 break;
@@ -66,6 +71,15 @@ $(document).ready(function () {
             username: $(this).val(),
         };
         console.log(jsonData);
+        socket.send(JSON.stringify(jsonData));
+    });
+
+    $messageField.on("input", function () {
+        if (typingTimer) clearTimeout(typingTimer);
+        const jsonData = {
+            action: "typing",
+            username: $userField.val(),
+        };
         socket.send(JSON.stringify(jsonData));
     });
 
@@ -116,6 +130,15 @@ $(document).ready(function () {
                 $recipientSelect.append(`<option value="${user}">${user}</option>`);
             }
         });
+    }
+
+    // Display input indicators
+    function showTypingIndicator(username) {
+        const typingIndicator = `${username} is typing...`;
+        $("#typing-indicator").text(typingIndicator).show();
+        setTimeout(() => {
+            $("#typing-indicator").hide();
+        }, 3000);
     }
 
     //  Clean broadcast message with timestamp

--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -110,6 +110,11 @@ func ListenToWsChannel() {
 			response.ConnectedUsers = getUserList()
 			broadcastToAll(response)
 
+		case "typing":
+			response.Action = "typing"
+			response.From = e.Username
+			broadcastToAll(response)
+
 		case "left":
 			response.Action = "list_users"
 			delete(hub.Clients, e.Conn)

--- a/templates/home.html
+++ b/templates/home.html
@@ -48,6 +48,7 @@
                             <button id="sendButton" class="btn btn-primary">Send Message</button>
                             <div id="status"></div>
                         </div>
+                        <div id="typing-indicator" class="text-muted" style="display: none;"></div>
                         <div id="output" class="chatbox mt-3"></div>
                     </div>
                 </div>


### PR DESCRIPTION
# Pull Request Template

## Description

Add a feature to show user who is typing on the chat room, and the notification will display(like `arya is typing`) in 3 seconds. After 3 seconds, the notification disappeared immediately.
This feature improves the user experience that users can easily to know who is typing.

## Type of Change

- [✅] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I tested the feature for opening two web pages and checked there was a notification about who is typing when a user is typing, and it will disappear after 3 seconds.

## Checklist:

- [✅] My code follows the style guidelines of this project