### PR TITLE
[FEAT] : Added support gracefully shutdown on server error

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,25 +1,69 @@
+// Our previous code use
+// log.Fatal(http.ListenAndServe(":8080", mux))
+
 package main
 
 import (
+	"context"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"time"
 
 	"github.com/arya2004/gobanter/pkg/handlers"
 	"github.com/arya2004/gobanter/pkg/routes"
 )
 
 // main is the entry point of the application
+
 func main() {
-	// Initialize the application routes
+
+	// initialize the application routes
+
 	mux := routes.Routes()
 
-	// Start a goroutine to listen for WebSocket messages
-	log.Println("Starting WebSocket channel listener...")
+	//start a goroutine to listen for websocket messages
+
+	log.Println("Starting WebSocket Channel listener...")
 	go handlers.ListenToWsChannel()
 
-	// Start the HTTP server on port 8080
-	log.Println("Server starting on port 8080...")
-	if err := http.ListenAndServe(":8080", mux); err != nil {
-		log.Fatalf("Error starting server: %v", err)
+	// creating a custon HTTP server for better control
+
+	server := &http.Server{
+		Addr:    ":8080",
+		Handler: mux,
+	}
+
+	// channel to catch OS signals like ctrl + c
+
+	stop := make(chan os.Signal, 1)
+	signal.Notify(stop, os.Interrupt)
+
+	// starting the  server in a goroutine
+
+	go func() {
+		log.Println("Server starting on port 8080....")
+		if err := server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("Server startup error: %v", err)
+		}
+	}()
+
+	// block until an interrupt signal is received
+
+	<-stop
+	log.Println("Shutdown signal received, attempting graceful shutdown...")
+
+	// creating a deadline for shutdown
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// attempt to gracefully shut down the server
+
+	if err := server.Shutdown(ctx); err != nil {
+		log.Printf("Graceful shutdown failed: %v", err)
+	} else {
+		log.Println("Server shut down cleanly")
 	}
 }


### PR DESCRIPTION
Changes are made in the main.go file , added support for gracefully shutdown the server error.

Things are done : 

-> Used http.Server (instead of http.ListenAndServe)
-> Handling system interrupts (Ctrl+C)
-> Using a context.WithTimeout() for graceful shutdown
-> Keeping structured, minimal logs