### PR TITLE
[Fix] : Added the check for websocket upgrader to prevent CSWH attacks

### DIFF
--- a/pkg/handlers/handlers.go
+++ b/pkg/handlers/handlers.go
@@ -34,7 +34,10 @@ var (
 	upgradeConnection = websocket.Upgrader{
 		ReadBufferSize:  1024,
 		WriteBufferSize: 1024,
-		CheckOrigin:     func(r *http.Request) bool { return true },
+		CheckOrigin: func(r *http.Request) bool {
+			origin := r.Header.Get("Origin")
+			return origin == "http://localhost:8080"
+		},
 	}
 )
 


### PR DESCRIPTION
Added the  check for websocket.Upgrader to prevent the CSWH

-> CSWH (Cross site webSocket hijacking) it is generally a CSRF (cross site request forgery ) vulnerability 

